### PR TITLE
Fix Vercel preview deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "postinstall": "node scripts/copy-fonts.cjs",
     "dev": "astro dev",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "framework": "astro",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm ci",
+  "git": {
+    "deploymentEnabled": {
+      "master": false
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "framework": "astro",
+  "engines": {
+    "node": "24.x"
+  },
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "installCommand": "npm ci",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "framework": "astro",
-  "engines": {
-    "node": "24.x"
-  },
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "installCommand": "npm ci",


### PR DESCRIPTION
## Problem

Vercel was failing to build on every push. Two issues:

1. The package name (`vite_react_shadcn_ts`) was causing Vercel to misidentify the framework, so it wasn't using the right build pipeline for Astro.
2. Vercel was attempting production deployments on `master`, which is undesirable — GitHub Pages is the real production environment.

## Fix

Adds a `vercel.json` that:
- Explicitly sets `"framework": "astro"` so Vercel uses the correct preset
- Pins `buildCommand`, `outputDirectory`, and `installCommand` to remove ambiguity
- Sets `"deploymentEnabled": { "master": false }` to disable Vercel production deploys on `master` while keeping PR preview environments alive

## Test plan

- [ ] Vercel preview deployment succeeds on this PR
- [ ] Vercel does **not** create a production deployment when this merges to `master`
- [ ] GitHub Pages deploy on `master` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)