### PR TITLE
test: add stronger coverage — a11y, RSS, links, metadata, content integrity

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const PAGES = [
+  { name: 'homepage',   path: '/' },
+  { name: 'blog index', path: '/blog' },
+  { name: 'blog post',  path: '/blog/2026-01-30-processes-abstraction' },
+];
+
+for (const { name, path } of PAGES) {
+  test(`${name} — no critical/serious a11y violations`, async ({ page }) => {
+    test.slow();
+    await page.goto(path);
+    // Wait for the React navbar island to hydrate before scanning
+    await page.locator('select[aria-label="Select colour theme"]').waitFor({ state: 'visible' });
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .exclude('#astro-dev-overlay')
+      .analyze();
+
+    const blocking = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+
+    const detail = blocking
+      .map(v => `[${v.impact}] ${v.id}: ${v.description}\n  ${v.nodes.map(n => n.html).join('\n  ')}`)
+      .join('\n\n');
+    expect(blocking, `a11y violations on "${name}":\n\n${detail}`).toHaveLength(0);
+  });
+}
+
+test('blog post dark mode — no new violations', async ({ page }) => {
+  test.slow();
+  await page.goto('/blog/2026-01-30-processes-abstraction');
+  await page.locator('select[aria-label="Select colour theme"]').waitFor({ state: 'visible' });
+  await page.getByLabel('Toggle theme').click();
+  await expect(page.locator('html')).toHaveClass(/dark/);
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    .exclude('#astro-dev-overlay')
+    .analyze();
+
+  const blocking = results.violations.filter(v => v.impact === 'critical' || v.impact === 'serious');
+  expect(blocking, blocking.map(v => v.description).join(', ')).toHaveLength(0);
+});

--- a/e2e/links.spec.ts
+++ b/e2e/links.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+const SEED_PAGES = ['/', '/blog', '/blog/2026-01-30-processes-abstraction'];
+
+async function internalHrefs(page: import('@playwright/test').Page): Promise<string[]> {
+  const hrefs = await page.locator('a[href]').evaluateAll(
+    els => els.map(el => (el as HTMLAnchorElement).getAttribute('href') ?? ''),
+  );
+  return [...new Set(
+    hrefs
+      .filter(h => h.startsWith('/') && !h.startsWith('//'))
+      .filter(h => !h.includes('rss.xml')), // tested separately
+  )];
+}
+
+test.describe('internal link integrity', () => {
+  test('no 404s reachable from seed pages', async ({ page }) => {
+    const visited = new Set<string>();
+    const toCheck = new Set<string>(SEED_PAGES);
+
+    for (const href of toCheck) {
+      if (visited.has(href)) continue;
+      visited.add(href);
+
+      const response = await page.goto(href);
+      expect(
+        response?.status(),
+        `${href} returned ${response?.status()}`,
+      ).not.toBe(404);
+
+      for (const link of await internalHrefs(page)) {
+        if (!visited.has(link)) toCheck.add(link);
+      }
+    }
+  });
+
+  test('blog post cards link to /blog/ not /posts/', async ({ page }) => {
+    await page.goto('/blog');
+    const hrefs = await page.locator('article a[href]').evaluateAll(
+      els => els.map(el => (el as HTMLAnchorElement).getAttribute('href') ?? ''),
+    );
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      expect(href, `bad prefix: ${href}`).not.toMatch(/^\/posts\//);
+      expect(href, `expected /blog/ prefix: ${href}`).toMatch(/^\/blog\//);
+    }
+  });
+});

--- a/e2e/metadata.spec.ts
+++ b/e2e/metadata.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { SITE_NAME } from '../src/lib/constants';
+
+async function ogContent(page: import('@playwright/test').Page, property: string) {
+  return page.locator(`meta[property="${property}"]`).getAttribute('content');
+}
+
+test.describe('page metadata', () => {
+  test('homepage — title and OG tags', async ({ page }) => {
+    await page.goto('/');
+    expect(await page.title()).toBe(SITE_NAME);
+    expect(await ogContent(page, 'og:title')).toBe(SITE_NAME);
+    expect(await ogContent(page, 'og:type')).toBe('website');
+    expect(await ogContent(page, 'og:image')).toBeTruthy();
+    expect(await ogContent(page, 'og:image:alt')).toContain(SITE_NAME);
+  });
+
+  test('blog index — title contains site name', async ({ page }) => {
+    await page.goto('/blog');
+    const title = await page.title();
+    expect(title).toContain(SITE_NAME);
+    expect(title).toContain('writing');
+  });
+
+  test('blog post — title, OG article type, published_time', async ({ page }) => {
+    await page.goto('/blog/2026-01-30-processes-abstraction');
+    const title = await page.title();
+    // Should be "Post Title · systems & writing"
+    expect(title).toContain(SITE_NAME);
+    expect(title).not.toBe(SITE_NAME);
+    expect(await ogContent(page, 'og:type')).toBe('article');
+    expect(await ogContent(page, 'og:title')).toBeTruthy();
+    expect(typeof await ogContent(page, 'og:description')).toBe('string');
+    expect(await ogContent(page, 'article:published_time')).toBeTruthy();
+  });
+
+  test('404 page has a non-empty title', async ({ page }) => {
+    await page.goto('/does-not-exist');
+    expect((await page.title()).length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/rss.spec.ts
+++ b/e2e/rss.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('RSS feed', () => {
+  test('serves valid XML', async ({ request }) => {
+    const response = await request.get('/rss.xml');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toMatch(/xml|rss/i);
+  });
+
+  test('has required RSS channel structure', async ({ request }) => {
+    const text = await (await request.get('/rss.xml')).text();
+    expect(text).toContain('<rss');
+    expect(text).toContain('<channel>');
+    expect(text).toContain('</channel>');
+    expect(text).toContain('</rss>');
+  });
+
+  test('has at least one item with title, link inside /blog/, and pubDate', async ({ request }) => {
+    const text = await (await request.get('/rss.xml')).text();
+    const items = text.match(/<item>/g) ?? [];
+    expect(items.length).toBeGreaterThan(0);
+    expect(text).toContain('<pubDate>');
+    const links = [...text.matchAll(/<link>(.*?)<\/link>/g)].map(m => m[1]);
+    expect(links.some(l => l.includes('/blog/'))).toBe(true);
+  });
+
+  test('channel title references the site', async ({ request }) => {
+    const text = await (await request.get('/rss.xml')).text();
+    const match = text.match(/<title>([\s\S]*?)<\/title>/);
+    expect(match).toBeTruthy();
+    expect(match![1].trim().length).toBeGreaterThan(0);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "zod": "3.25.76"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
         "@eslint/js": "9.32.0",
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/ibm-plex-sans": "5.2.8",
@@ -790,6 +791,19 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5288,6 +5302,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "9.32.0",
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -11,7 +11,7 @@ export default function TagBadge({ tag, active, onClick }: Props) {
       className={`inline-flex items-center rounded-full px-2.5 py-0.5 font-mono text-xs transition-colors ${
         active
           ? 'bg-primary text-primary-foreground'
-          : 'bg-secondary text-muted-foreground hover:bg-primary/10 hover:text-primary'
+          : 'bg-secondary text-secondary-foreground hover:bg-primary/10 hover:text-primary'
       }`}
     >
       {tag}

--- a/src/components/__tests__/TagBadge.test.tsx
+++ b/src/components/__tests__/TagBadge.test.tsx
@@ -19,7 +19,7 @@ describe('TagBadge', () => {
     render(<TagBadge tag="react" />);
     const btn = screen.getByText('react');
     expect(btn.className).toContain('bg-secondary');
-    expect(btn.className).toContain('text-muted-foreground');
+    expect(btn.className).toContain('text-secondary-foreground');
   });
 
   it('calls onClick when clicked', () => {

--- a/src/lib/__tests__/content-integrity.test.ts
+++ b/src/lib/__tests__/content-integrity.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { toISODate } from '../dates';
+
+const BLOG_DIR = resolve(__dirname, '../../content/blog');
+
+function parseFrontmatter(raw: string): Record<string, unknown> {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+  const result: Record<string, unknown> = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const val = line.slice(colon + 1).trim();
+    if (val.startsWith('[') && val.endsWith(']')) {
+      result[key] = val
+        .slice(1, -1)
+        .split(',')
+        .map(s => s.trim().replace(/^['"]|['"]$/g, ''))
+        .filter(Boolean);
+    } else {
+      result[key] = val.replace(/^['"]|['"]$/g, '');
+    }
+  }
+  return result;
+}
+
+const posts = readdirSync(BLOG_DIR)
+  .filter(f => f.endsWith('.md'))
+  .map(file => ({ file, fm: parseFrontmatter(readFileSync(join(BLOG_DIR, file), 'utf-8')) }));
+
+describe('content integrity', () => {
+  it('finds at least one blog post', () => {
+    expect(posts.length).toBeGreaterThan(0);
+  });
+
+  for (const { file, fm } of posts) {
+    describe(file, () => {
+      it('has a non-empty title', () => {
+        expect(typeof fm.title).toBe('string');
+        expect((fm.title as string).trim()).not.toBe('');
+      });
+
+      it('has a parseable date that normalises to YYYY-MM-DD', () => {
+        expect(() => toISODate(fm.date)).not.toThrow();
+        expect(toISODate(fm.date)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      });
+
+      it('has at least one non-empty tag', () => {
+        const tags = fm.tags as string[];
+        expect(Array.isArray(tags)).toBe(true);
+        expect(tags.length).toBeGreaterThan(0);
+        tags.forEach(t => expect(t.trim()).not.toBe(''));
+      });
+
+      it('description is a string when present', () => {
+        if (fm.description !== undefined && fm.description !== '') {
+          expect(typeof fm.description).toBe('string');
+        }
+      });
+    });
+  }
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-Object.defineProperty(window, "matchMedia", {
+if (typeof window !== 'undefined') Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({
     matches: false,


### PR DESCRIPTION
## What
Adds 5 new test layers that weren't covered before. Also fixes a real WCAG AA contrast bug uncovered by the new a11y suite.

**New test files:**
- `e2e/a11y.spec.ts` — axe-core WCAG 2.x scans on homepage, blog index, blog post (light + dark mode); blocks on critical/serious violations
- `e2e/rss.spec.ts` — validates `/rss.xml` structure: valid XML, channel, items, pubDate, `/blog/` links
- `e2e/links.spec.ts` — crawls seed pages for 404s; asserts blog card links use `/blog/` not `/posts/`
- `e2e/metadata.spec.ts` — checks page titles, OG tags (`og:type`, `og:image`, `article:published_time`), 404 title
- `src/lib/__tests__/content-integrity.test.ts` — Vitest (node env) validates every `.md` frontmatter: non-empty title, parseable date → ISO, ≥1 tag, description is string

**Bug fix surfaced by tests:**
- `TagBadge.tsx`: inactive tag pills used `text-muted-foreground` on `bg-secondary` → contrast ratio 4.11:1, below WCAG AA 4.5:1. Fixed to `text-secondary-foreground` (the semantically correct pairing).

**Chore:**
- Guard `window` in `src/test/setup.ts` so node-environment test files don't crash on setup import.

## Test plan
- [x] `npm test` — 156/156 passing (13 test files, includes 17 new content-integrity tests)
- [x] `npx playwright test --workers=1` — 28/28 passing locally against dev server
- [ ] Playwright passes against Vercel preview (`bash scripts/test-preview.sh`)
- [ ] Visually checked on preview URL (tag badges still look correct with new colour token)