### PR TITLE
feat: make rose-pine the default palette, remove default theme

### DIFF
--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -8,7 +8,7 @@ async function waitForNavbar(page: import('@playwright/test').Page) {
   await page.waitForLoadState('networkidle');
   const select = page.getByLabel('Select colour theme');
   await expect(select).toBeVisible({ timeout: 10_000 });
-  await expect(select).toHaveValue('default', { timeout: 5_000 });
+  await expect(select).toHaveValue('rose-pine', { timeout: 5_000 });
 }
 
 test.describe('Theme switching', () => {
@@ -69,11 +69,22 @@ test.describe('Theme switching', () => {
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'rose-pine');
   });
 
-  test('resetting palette to Default removes data-theme', async ({ page }) => {
-    await page.getByLabel('Select colour theme').selectOption('one-dark');
-    await expect(page.locator('html')).toHaveAttribute('data-theme', 'one-dark');
+  test('rose-pine palette is active by default with empty localStorage', async ({ page }) => {
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'rose-pine');
+    await expect(page.getByLabel('Select colour theme')).toHaveValue('rose-pine');
+  });
 
-    await page.getByLabel('Select colour theme').selectOption('default');
-    await expect(page.locator('html')).not.toHaveAttribute('data-theme');
+  test('Default option no longer appears in palette dropdown', async ({ page }) => {
+    const select = page.getByLabel('Select colour theme');
+    const options = await select.locator('option').allTextContents();
+    expect(options).not.toContain('Default');
+  });
+
+  test('fresh visitor gets rose-pine as active palette', async ({ page }) => {
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'rose-pine');
+    await expect(page.getByLabel('Select colour theme')).toHaveValue('rose-pine');
   });
 });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,11 +18,10 @@ function SunIcon() {
   );
 }
 
-const PALETTES = ['default', 'rose-pine', 'gruvbox', 'nord', 'one-dark'] as const;
+const PALETTES = ['rose-pine', 'gruvbox', 'nord', 'one-dark'] as const;
 type Palette = typeof PALETTES[number];
 
 const PALETTE_LABELS: Record<Palette, string> = {
-  'default':  'Default',
   'rose-pine':'Rosé Pine',
   'gruvbox':  'Gruvbox',
   'nord':     'Nord',
@@ -32,14 +31,12 @@ const PALETTE_LABELS: Record<Palette, string> = {
 function usePalette() {
   const [palette, setPaletteState] = useState<Palette>(() => {
     /* v8 ignore next -- SSR guard */
-    if (typeof window === 'undefined') return 'default';
-    return (localStorage.getItem('palette') as Palette) ?? 'default';
+    if (typeof window === 'undefined') return 'rose-pine';
+    return (localStorage.getItem('palette') as Palette) ?? 'rose-pine';
   });
 
   useEffect(() => {
-    const root = document.documentElement;
-    if (palette === 'default') root.removeAttribute('data-theme');
-    else root.setAttribute('data-theme', palette);
+    document.documentElement.setAttribute('data-theme', palette);
     localStorage.setItem('palette', palette);
   }, [palette]);
 

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -63,7 +63,7 @@ describe('Navbar', () => {
     renderNavbar();
     const select = screen.getByLabelText('Select colour theme') as HTMLSelectElement;
     expect(select).toBeInTheDocument();
-    expect(select.value).toBe('default');
+    expect(select.value).toBe('rose-pine');
   });
 
   it('sets data-theme attribute when palette changes', () => {
@@ -78,14 +78,6 @@ describe('Navbar', () => {
     const select = screen.getByLabelText('Select colour theme');
     fireEvent.change(select, { target: { value: 'nord' } });
     expect(localStorage.getItem('palette')).toBe('nord');
-  });
-
-  it('removes data-theme when palette reset to default', () => {
-    renderNavbar();
-    const select = screen.getByLabelText('Select colour theme');
-    fireEvent.change(select, { target: { value: 'gruvbox' } });
-    fireEvent.change(select, { target: { value: 'default' } });
-    expect(document.documentElement.getAttribute('data-theme')).toBeNull();
   });
 
   it('restores palette from localStorage on mount', () => {
@@ -112,17 +104,29 @@ describe('Navbar', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe('rose-pine');
   });
 
-  it('renders all five palette options', () => {
+  it('renders all four palette options', () => {
     renderNavbar();
     const select = screen.getByLabelText('Select colour theme') as HTMLSelectElement;
     const options = Array.from(select.options).map(o => o.value);
-    expect(options).toEqual(['default', 'rose-pine', 'gruvbox', 'nord', 'one-dark']);
+    expect(options).toEqual(['rose-pine', 'gruvbox', 'nord', 'one-dark']);
   });
 
   it('renders human-readable palette labels', () => {
     renderNavbar();
     const select = screen.getByLabelText('Select colour theme') as HTMLSelectElement;
     const labels = Array.from(select.options).map(o => o.text);
-    expect(labels).toEqual(['Default', 'Rosé Pine', 'Gruvbox', 'Nord', 'One Dark Pro']);
+    expect(labels).toEqual(['Rosé Pine', 'Gruvbox', 'Nord', 'One Dark Pro']);
+  });
+
+  it('fresh mount sets data-theme to rose-pine on html element', () => {
+    renderNavbar();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('rose-pine');
+  });
+
+  it('does not include a Default option in the palette dropdown', () => {
+    renderNavbar();
+    const select = screen.getByLabelText('Select colour theme') as HTMLSelectElement;
+    const values = Array.from(select.options).map(o => o.value);
+    expect(values).not.toContain('default');
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -177,17 +177,17 @@
   --card-foreground:    248 17% 39%;
   --popover:             32 57% 95%;
   --popover-foreground: 248 17% 39%;
-  --primary:              4 52% 66%;   /* #d7827a  rose       */
+  --primary:            344 35% 42%;   /* #914656  dark rose, 6:1 contrast  */
   --primary-foreground:  32 57% 95%;
   --secondary:           25 38% 91%;
   --secondary-foreground:248 17% 39%;
   --muted:               25 38% 91%;
-  --muted-foreground:   276  8% 62%;   /* #9893a5             */
-  --accent:               4 52% 66%;
+  --muted-foreground:   252 10% 44%;   /* #696579  subtle, 5.1:1 contrast   */
+  --accent:             344 35% 42%;
   --accent-foreground:   32 57% 95%;
   --border:               6 11% 86%;   /* #dfdad9             */
   --input:                6 11% 86%;
-  --ring:                 4 52% 66%;
+  --ring:               344 35% 42%;
   --code-bg:             25 38% 91%;
   --code-border:          6 11% 86%;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,11 +3,12 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 export default defineConfig({
+  root: __dirname,
   plugins: [react()],
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: ["./src/test/setup.ts"],
+    setupFiles: [path.resolve(__dirname, "./src/test/setup.ts")],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## What
Removes the 'Default' palette option. Rose Pine is now the default theme for all fresh visitors. The \`data-theme\` attribute is always set on \`<html>\` (no more attribute-less state).

## Test plan
- [ ] \`npm test\` passes
- [ ] \`npx playwright test e2e/theme.spec.ts\` passes
- [ ] Manually: open site with cleared localStorage, confirm rose-pine is active and dropdown shows "Rosé Pine"
- [ ] Confirm "Default" option is absent from dropdown